### PR TITLE
Kubernetes controllers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,43 +1,67 @@
-# Выполнено ДЗ № 1
+# Выполнено ДЗ № 2
 
  - [x] Основное ДЗ
  - [x] Задание со *
 
 ## В процессе сделано:
- - Установлен kubctl
- - Установлен Minikube
- - Установлен Kubernetes Dashboard
- - Проверен k9s
- - Проверенны основные комманды kubectl
- - Настроен Deployment core-dns
- - Собран docker образ и помещен в публичный репозиторий
- - Создан манифест для запуска web сервера и расшраен volume с init контейнером
- - Установлен kube-forwarder
- - Собран образ сервиса frontend приложения Hipster Shop
- - Произведенна попытка запуска frontend сервиса на k8s
- - Исправлен манифест для запуска сервиса frontend
+ - Установлен kind
+ - Настроен кластер
+ - Создан манифест frontend ReplicaSet
+ - Исправлен манифест frontend ReplicaSet
+ - Произведенно масштабирование frontend реплик
+ - Изменен манифест frontend ReplicaSet для автоматического масштабирования
+ - Обновлен образ контейнера frontend
+ - Вопрос: "Почему обновление ReplicaSet не повлекло обновление
+запущенных pod?". Ответ: "Replica**Controller не умеют рестартовать запущенные поды при обновлении шаблона"
+ - Создан манифест для запуска ReplicaSet и Deployment сервиса paymentservice
+ - Обновлен манифест сервиса paymentservice
+ - Произведен откат deployment сервиса paymentservice
+ - Подготовлен манифест для blue-green и Reverse Rolling Update deployment сервиса paymentservice
+ - Создан манифест deployment сервиса frontend с настройкой readinessProbe
+ - Заменено в описании пробы URL /_healthz на /_health
+ - Создан манифест для DeamonSet сервиса node-exporter
 
 ## Как запустить проект:
- - Первый сервис:
+ - Подготовка кластера (если нет развернутого):
  ```bash
-kubectl apply -f web-pod.yaml
-kubectl port-forward --address 0.0.0.0 pod/web 8000:8000
+ kind create cluster --config kind-config.yaml
  ```
- - Сервис frontend приложения Hipster Shop
+ - Настройка и проверка ReplicaSet сервиса frontend:
  ```bash
- kubectl apply -f frontend-pod.yaml
+ kubectl apply -f frontend-replicaset.yaml | kubectl get pods -l app=frontend -w
  ```
-  - Исправленый манифест сервиса frontend
+ - Настройка и проверка ReplicaSet и Deployment сервиса paymentservice:
  ```bash
- kubectl apply -f frontend-pod-healthy.yaml
+ kubectl apply -f paymentservice-replicaset.yaml
+ kubectl get pods -l app=paymentservice -w
+
+ kubectl apply -f paymentservice-deployment.yaml
+ kubectl get pods -l app=paymentservice -w
+ ```
+  - Настройка и проверка blue-green и Deployment сервиса paymentservice:
+ ```bash
+ kubectl apply -f paymentservice-deployment-bg.yaml | kubectl get pods -l app=paymentservice -w
+
+ kubectl apply -f paymentservice-deployment-reverse.yaml | kubectl get pods -l app=paymentservice -w
+ ```
+  - Настройка и проверка DeamonSet сервиса node-exporter:
+ ```bash
+ kubectl apply -f node-exporter-daemonset.yaml
+ kubectl get pod -o wide
+ kubectl port-forward <имя любого pod в DaemonSet> 9100:9100
  ```
 
 ## Как проверить работоспособность:
- - Перейти по ссылке http://localhost:8000 для проверки первого сервиса 
- - Проверить сервис frontend и его исправленную версию можно командой:
-  ```bash
-kubectl apply -f frontend-pod-healthy.yaml
+ - Проверить корректность применения манифестов можно командой:
+ ```bash
+ kubectl get pods -l app=<имя сервиса>
+ ```
+ - Проверить сервис node-exporter можно командой:
+ ```bash
+ curl localhost:9100/metrics
  ```
 
 ## PR checklist:
  - [x] Выставлен label с номером домашнего задания
+
+ 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # kystkysto_platform
 kystkysto Platform repository
 - [Первое домашнее задание](kubernetes-intro/README.md)
+- [Второе домашнее задание](kubernetes-controllers/README.md)

--- a/kubernetes-controllers/README.md
+++ b/kubernetes-controllers/README.md
@@ -1,0 +1,39 @@
+## Как запустить проект:
+ - Подготовка кластера (если нет развернутого):
+ ```bash
+ kind create cluster --config kind-config.yaml
+ ```
+ - Настройка и проверка ReplicaSet сервиса frontend:
+ ```bash
+ kubectl apply -f frontend-replicaset.yaml | kubectl get pods -l app=frontend -w
+ ```
+ - Настройка и проверка ReplicaSet и Deployment сервиса paymentservice:
+ ```bash
+ kubectl apply -f paymentservice-replicaset.yaml
+ kubectl get pods -l app=paymentservice -w
+
+ kubectl apply -f paymentservice-deployment.yaml
+ kubectl get pods -l app=paymentservice -w
+ ```
+  - Настройка и проверка blue-green и Deployment сервиса paymentservice:
+ ```bash
+ kubectl apply -f paymentservice-deployment-bg.yaml | kubectl get pods -l app=paymentservice -w
+
+ kubectl apply -f paymentservice-deployment-reverse.yaml | kubectl get pods -l app=paymentservice -w
+ ```
+  - Настройка и проверка DeamonSet сервиса node-exporter:
+ ```bash
+ kubectl apply -f node-exporter-daemonset.yaml
+ kubectl get pod -o wide
+ kubectl port-forward <имя любого pod в DaemonSet> 9100:9100
+ ```
+
+## Как проверить работоспособность:
+ - Проверить корректность применения манифестов можно командой:
+ ```bash
+ kubectl get pods -l app=<имя сервиса>
+ ```
+ - Проверить сервис node-exporter можно командой:
+ ```bash
+ curl localhost:9100/metrics
+ ```

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -21,7 +21,7 @@ spec:
               readinessProbe:
                 initialDelaySeconds: 10
                 httpGet:
-                  path: "/_health"
+                  path: "/_healthz"
                   port: 8080
                   httpHeaders:
                   - name: "Cookie"

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: frontend
+    labels:
+        app: frontend
+spec:
+    replicas: 3
+    selector:
+        matchLabels:
+            tier: frontend
+    template:
+        metadata:
+            labels:
+                app: frontend
+                tier: frontend
+        spec:
+            containers:
+            - name: server
+              image: kystkysto/frontend:v0.0.2
+              readinessProbe:
+                initialDelaySeconds: 10
+                httpGet:
+                  path: "/_health"
+                  port: 8080
+                  httpHeaders:
+                  - name: "Cookie"
+                    value: "shop_session-id=x-readiness-probe"
+              env:
+                - name: PORT
+                  value: "8080"
+                - name: PRODUCT_CATALOG_SERVICE_ADDR
+                  value: "productcatalogservice:3550"
+                - name: CURRENCY_SERVICE_ADDR
+                  value: "currencyservice:7000"
+                - name: CART_SERVICE_ADDR
+                  value: "cartservice:7070"
+                - name: RECOMMENDATION_SERVICE_ADDR
+                  value: "recommendationservice:8080"
+                - name: SHIPPING_SERVICE_ADDR
+                  value: "shippingservice:50051"
+                - name: CHECKOUT_SERVICE_ADDR
+                  value: "checkoutservice:5050"
+                - name: AD_SERVICE_ADDR
+                  value: "adservice:9555"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -5,7 +5,7 @@ metadata:
     labels:
         app: frontend
 spec:
-    replicas: 1
+    replicas: 3
     selector:
         matchLabels:
             tier: frontend

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+    name: frontend
+    labels:
+        app: frontend
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            tier: frontend
+    template:
+        metadata:
+            labels:
+                app: frontend
+                tier: frontend
+        spec:
+            containers:
+            - name: server
+              image: kystkysto/frontend:latest
+              env:
+                - name: PORT
+                  value: "8080"
+                - name: PRODUCT_CATALOG_SERVICE_ADDR
+                  value: "productcatalogservice:3550"
+                - name: CURRENCY_SERVICE_ADDR
+                  value: "currencyservice:7000"
+                - name: CART_SERVICE_ADDR
+                  value: "cartservice:7070"
+                - name: RECOMMENDATION_SERVICE_ADDR
+                  value: "recommendationservice:8080"
+                - name: SHIPPING_SERVICE_ADDR
+                  value: "shippingservice:50051"
+                - name: CHECKOUT_SERVICE_ADDR
+                  value: "checkoutservice:5050"
+                - name: AD_SERVICE_ADDR
+                  value: "adservice:9555"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -17,7 +17,7 @@ spec:
         spec:
             containers:
             - name: server
-              image: kystkysto/frontend:latest
+              image: kystkysto/frontend:v0.0.2
               env:
                 - name: PORT
                   value: "8080"

--- a/kubernetes-controllers/kind-config.yaml
+++ b/kubernetes-controllers/kind-config.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+- role: control-plane
+- role: control-plane
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: node-exporter
+  name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+    spec:
+      containers:
+      - args:
+        - --web.listen-address=127.0.0.1:9100
+        - --path.procfs=/host/proc
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
+        - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+        image: quay.io/prometheus/node-exporter:v0.18.1
+        name: node-exporter
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/proc
+          name: proc
+          readOnly: false
+        - mountPath: /host/sys
+          name: sys
+          readOnly: false
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --secure-listen-address=[$(IP)]:9100
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --upstream=http://127.0.0.1:9100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: https
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /proc
+        name: proc
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: paymentservice
+    labels:
+        app: paymentservice
+spec:
+    replicas: 3
+    strategy:
+        rollingUpdate:
+          maxSurge: 100%
+          maxUnavailable: 0
+    selector:
+        matchLabels:
+            tier: paymentservice
+    template:
+        metadata:
+            labels:
+                app: paymentservice
+                tier: paymentservice
+        spec:
+            containers:
+            - name: server
+              image: kystkysto/paymentservice:v0.0.1

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: paymentservice
+    labels:
+        app: paymentservice
+spec:
+    replicas: 3
+    strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1
+    selector:
+        matchLabels:
+            tier: paymentservice
+    template:
+        metadata:
+            labels:
+                app: paymentservice
+                tier: paymentservice
+        spec:
+            containers:
+            - name: server
+              image: kystkysto/paymentservice:v0.0.1

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-    name: payment
+    name: paymentservice
     labels:
-        app: payment
+        app: paymentservice
 spec:
     replicas: 3
     selector:
         matchLabels:
-            tier: payment
+            tier: paymentservice
     template:
         metadata:
             labels:
-                app: payment
-                tier: payment
+                app: paymentservice
+                tier: paymentservice
         spec:
             containers:
             - name: server
-              image: kystkysto/paymentservice:v0.0.1
+              image: kystkysto/paymentservice:v0.0.2

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: payment
+    labels:
+        app: payment
+spec:
+    replicas: 3
+    selector:
+        matchLabels:
+            tier: payment
+    template:
+        metadata:
+            labels:
+                app: payment
+                tier: payment
+        spec:
+            containers:
+            - name: server
+              image: kystkysto/paymentservice:v0.0.1

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-    name: payment
+    name: paymentservice
     labels:
-        app: payment
+        app: paymentservice
 spec:
     replicas: 3
     selector:
         matchLabels:
-            tier: payment
+            tier: paymentservice
     template:
         metadata:
             labels:
-                app: payment
-                tier: payment
+                app: paymentservice
+                tier: paymentservice
         spec:
             containers:
             - name: server

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+    name: payment
+    labels:
+        app: payment
+spec:
+    replicas: 3
+    selector:
+        matchLabels:
+            tier: payment
+    template:
+        metadata:
+            labels:
+                app: payment
+                tier: payment
+        spec:
+            containers:
+            - name: server
+              image: kystkysto/paymentservice:v0.0.1


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Установлен kind
 - Настроен кластер
 - Создан манифест frontend ReplicaSet
 - Исправлен манифест frontend ReplicaSet
 - Произведенно масштабирование frontend реплик
 - Изменен манифест frontend ReplicaSet для автоматического масштабирования
 - Обновлен образ контейнера frontend
 - Вопрос: "Почему обновление ReplicaSet не повлекло обновление
запущенных pod?". Ответ: "Replica**Controller не умеют рестартовать запущенные поды при обновлении шаблона"
 - Создан манифест для запуска ReplicaSet и Deployment сервиса paymentservice
 - Обновлен манифест сервиса paymentservice
 - Произведен откат deployment сервиса paymentservice
 - Подготовлен манифест для blue-green и Reverse Rolling Update deployment сервиса paymentservice
 - Создан манифест deployment сервиса frontend с настройкой readinessProbe
 - Заменено в описании пробы URL /_healthz на /_health
 - Создан манифест для DeamonSet сервиса node-exporter

## Как запустить проект:
 - Подготовка кластера (если нет развернутого):
 ```bash
 kind create cluster --config kind-config.yaml
 ```
 - Настройка и проверка ReplicaSet сервиса frontend:
 ```bash
 kubectl apply -f frontend-replicaset.yaml | kubectl get pods -l app=frontend -w
 ```
 - Настройка и проверка ReplicaSet и Deployment сервиса paymentservice:
 ```bash
 kubectl apply -f paymentservice-replicaset.yaml
 kubectl get pods -l app=paymentservice -w

 kubectl apply -f paymentservice-deployment.yaml
 kubectl get pods -l app=paymentservice -w
 ```
  - Настройка и проверка blue-green и Deployment сервиса paymentservice:
 ```bash
 kubectl apply -f paymentservice-deployment-bg.yaml | kubectl get pods -l app=paymentservice -w

 kubectl apply -f paymentservice-deployment-reverse.yaml | kubectl get pods -l app=paymentservice -w
 ```
  - Настройка и проверка DeamonSet сервиса node-exporter:
 ```bash
 kubectl apply -f node-exporter-daemonset.yaml
 kubectl get pod -o wide
 kubectl port-forward <имя любого pod в DaemonSet> 9100:9100
 ```

## Как проверить работоспособность:
 - Проверить корректность применения манифестов можно командой:
 ```bash
 kubectl get pods -l app=<имя сервиса>
 ```
 - Проверить сервис node-exporter можно командой:
 ```bash
 curl localhost:9100/metrics
 ```

## PR checklist:
 - [x] Выставлен label с номером домашнего задания

 